### PR TITLE
Refactor library

### DIFF
--- a/src/components/LabelInput.js
+++ b/src/components/LabelInput.js
@@ -35,6 +35,7 @@ const LabelInput = () => {
         placeholder="Add a label"
         onChange={handleChange}
         onKeyDown={e => e.keyCode === 13 && handleSubmitLabel(e)}
+        onBlur={handleSubmitLabel}
       />
       <datalist id="labels">
         {SUGGESTED_LABELS.filter(l => !labelArray.includes(l)).map(label => (

--- a/src/lib/index.js
+++ b/src/lib/index.js
@@ -1,10 +1,4 @@
-import join from "lodash/fp/join";
-import split from "lodash/fp/split";
-
-export { default as normalizeLabelString } from "./normalizeLabelString";
-export { default as normalizeQueryString } from "./normalizeQueryString";
-export { default as toQueryStringArray } from "./toQueryStringArray";
-export { default as subsequences } from "./subsequences";
-
-export const words = split(" ");
-export const unwords = join(" ");
+export { default as normalizeLabelString } from "lib/normalizeLabelString";
+export { default as normalizeQueryString } from "lib/normalizeQueryString";
+export { default as toQueryStringArray } from "lib/toQueryStringArray";
+export { default as subsequences } from "lib/subsequences";

--- a/src/lib/normalizeLabelString.js
+++ b/src/lib/normalizeLabelString.js
@@ -1,10 +1,12 @@
 import compose from "lodash/fp/compose";
-import replace from "lodash/fp/replace";
 import toLower from "lodash/fp/toLower";
 import trim from "lodash/fp/trim";
+import { removeExtraWhitespace } from "lib/string";
 
-export default compose(
+const normalizeLabelString = compose(
   toLower,
-  replace(/{ }+/g, ""),
+  removeExtraWhitespace,
   trim
 );
+
+export default normalizeLabelString;

--- a/src/lib/normalizeQueryString.js
+++ b/src/lib/normalizeQueryString.js
@@ -1,8 +1,10 @@
 import compose from "lodash/fp/compose";
-import replace from "lodash/fp/replace";
 import trim from "lodash/fp/trim";
+import { removeExtraWhitespace } from "lib/string";
 
-export default compose(
-  replace(/{ }+/g, ""),
+const normalizeQueryString = compose(
+  removeExtraWhitespace,
   trim
 );
+
+export default normalizeQueryString;

--- a/src/lib/string.js
+++ b/src/lib/string.js
@@ -1,0 +1,7 @@
+import join from "lodash/fp/join";
+import split from "lodash/fp/split";
+import replace from "lodash/fp/replace";
+
+export const words = split(" ");
+export const unwords = join(" ");
+export const removeExtraWhitespace = replace(/[ ]{2,}/g, " ");

--- a/src/lib/subsequences.js
+++ b/src/lib/subsequences.js
@@ -1,14 +1,14 @@
 import compose from "lodash/fp/compose";
 import reverse from "lodash/fp/reverse";
-import slice from "lodash/fp/slice";
 
 const powerset = xs => {
   const x = xs.shift();
   return x === undefined ? [[]] : powerset(xs).flatMap(r => [r.concat(x), r]);
 };
 
-export default compose(
-  slice(0, -1),
+const subsequences = compose(
   powerset,
   reverse
 );
+
+export { powerset, subsequences as default };

--- a/src/lib/subsequences.test.js
+++ b/src/lib/subsequences.test.js
@@ -1,4 +1,4 @@
-import subsequences from "./subsequences";
+import subsequences from "lib/subsequences";
 
 describe("subsequences", () => {
   it("returns the full array as first element", () => {
@@ -8,7 +8,7 @@ describe("subsequences", () => {
   it("returns all but last element from input array as second element", () => {
     expect(subsequences([1, 2, 3, 4])[1]).toEqual([1, 2, 3]);
   });
-  it("returns an empty array if given an empty array", () => {
-    expect(subsequences([])).toEqual([]);
+  it("returns an empty nested array if given an empty array", () => {
+    expect(subsequences([])).toEqual([[]]);
   });
 });

--- a/src/lib/toQueryStringArray.js
+++ b/src/lib/toQueryStringArray.js
@@ -1,18 +1,17 @@
-import { unwords } from ".";
-import normalizeQueryString from "./normalizeQueryString";
-import subsequences from "./subsequences";
+import { unwords } from "lib/string";
+import normalizeQueryString from "lib/normalizeQueryString";
+import subsequences from "lib/subsequences";
 
-export const toQueryString = ({ keywords = "", labels, language }) =>
+const toQueryString = ({ keywords = "", labels, language }) =>
   unwords([
     keywords,
     unwords(labels.map(label => `label:"${label}"`)),
     language === "Any" ? "" : `language:${language}`
   ]);
 
-export default ({ keywords, labels, language }) =>
-  (labels.length > 0
-    ? subsequences(labels).map(ls =>
-        toQueryString({ keywords, labels: ls, language })
-      )
-    : [toQueryString({ keywords, labels, language })]
-  ).map(normalizeQueryString);
+const toQueryStringArray = ({ keywords, labels, language }) =>
+  subsequences(labels)
+    .map(ls => toQueryString({ keywords, labels: ls, language }))
+    .map(normalizeQueryString);
+
+export { toQueryString, toQueryStringArray as default };

--- a/src/lib/toQueryStringArray.test.js
+++ b/src/lib/toQueryStringArray.test.js
@@ -1,4 +1,5 @@
-import toQueryStringArray from "./toQueryStringArray";
+import last from "lodash/fp/last";
+import toQueryStringArray from "lib/toQueryStringArray";
 
 describe("toQueryStringArray", () => {
   it("constructs a valid query given non-empty keywords, labels, and language", () => {
@@ -7,7 +8,7 @@ describe("toQueryStringArray", () => {
       labels: ["good first issue", "help wanted"],
       language: "JavaScript"
     };
-    expect(toQueryStringArray(input)).toHaveLength(3);
+    expect(toQueryStringArray(input)).toHaveLength(4);
     expect(toQueryStringArray(input)[0]).toBe(
       'test label:"good first issue" label:"help wanted" language:JavaScript'
     );
@@ -17,6 +18,7 @@ describe("toQueryStringArray", () => {
     expect(toQueryStringArray(input)[2]).toBe(
       'test label:"help wanted" language:JavaScript'
     );
+    expect(last(toQueryStringArray(input))).toBe("test language:JavaScript");
   });
   it("constructs a valid query given empty labels array", () => {
     const input = {
@@ -26,7 +28,7 @@ describe("toQueryStringArray", () => {
     };
     expect(toQueryStringArray(input)).toHaveLength(1);
     expect(toQueryStringArray(input)[0]).toBe(
-      "example search  language:JavaScript"
+      "example search language:JavaScript"
     );
   });
   it("constructs a valid query given empty search and empty labels array", () => {
@@ -44,7 +46,7 @@ describe("toQueryStringArray", () => {
       labels: ["help wanted", "good first issue"],
       language: "Any"
     };
-    expect(toQueryStringArray(input)).toHaveLength(3);
+    expect(toQueryStringArray(input)).toHaveLength(4);
     expect(toQueryStringArray(input)[0]).toBe(
       'example label:"help wanted" label:"good first issue"'
     );


### PR DESCRIPTION
Refactoring the library:
  - string functions are in a separate module `lib/string`
  - `import`/`export` statements are closer to normalized
  - an error in a regular expression has been corrected
  - `toQueryStringArray` will now also include search results with _no_ labels (hopefully this is compatible with the GitHub search API, it would allow queries with no `label` and no `keywords`)